### PR TITLE
add local and github builds

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,54 @@
+# GitHub Actions Setup
+
+## Android Build Workflow
+
+This repository includes a GitHub Action that automatically builds the Android app using a containerized build environment when a Pull Request is created or updated.
+
+### Build Approach
+
+The workflow uses a **containerized build** approach with the following benefits:
+- **Consistent environment**: Uses `reactnativecommunity/react-native-android` Docker image
+- **No external dependencies**: Builds directly using Android SDK and Gradle
+- **Full control**: Complete control over the build process
+- **Artifact storage**: APK files are stored as GitHub artifacts for easy download
+
+### No Secrets Required
+
+Unlike EAS builds, this containerized approach doesn't require any repository secrets. The build runs entirely within the GitHub Actions environment.
+
+### Workflow Triggers
+
+The workflow runs on:
+- Pull Request opened
+- Pull Request synchronized (new commits pushed)
+- Pull Request reopened
+
+### Build Process
+
+1. **Container Setup**: Uses React Native Android container with pre-installed Android SDK
+2. **Dependency Installation**: Installs npm dependencies
+3. **Expo Prebuild**: Generates native Android project from Expo configuration
+4. **Gradle Build**: Compiles and builds the release APK using Gradle
+5. **Artifact Upload**: Uploads the APK as a GitHub artifact
+
+### Build Configuration
+
+The workflow:
+- Uses `npx expo prebuild` to generate the Android project
+- Builds a release APK using `./gradlew assembleRelease`
+- Supports all Expo configurations from your `app.json`
+
+### Output
+
+When the workflow completes:
+- A comment is added to the PR with build status and APK size
+- If successful, the APK is uploaded as a GitHub artifact
+- You can download the APK from the "Artifacts" section of the workflow run
+- Build logs are available in the GitHub Actions tab
+
+### Downloading the APK
+
+1. Go to the workflow run in the Actions tab
+2. Scroll down to the "Artifacts" section
+3. Download the `android-apk-[commit-hash]` file
+4. Extract and install the APK on your Android device 

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Generate Expo Android project
         run: |
-          npx expo install --fix
           rm -rf android
+          npx expo install --fix
           npx expo prebuild --platform android
 
       - name: Setup Gradle wrapper permissions

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,0 +1,116 @@
+name: Build Android App on PR
+
+on:
+  pull_request:
+    branches: [ main, master, app-debasish ]
+    types: [ opened, synchronize, reopened ]
+
+jobs:
+  build-android:
+    name: Build Android APK
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup Expo CLI
+        run: npm install -g @expo/cli
+
+      - name: Create local.properties
+        run: |
+          echo "sdk.dir=/opt/android" > android/local.properties
+          echo "ndk.dir=/opt/ndk" >> android/local.properties
+
+      - name: Generate Expo Android project
+        run: |
+          npx expo install --fix
+          rm -rf android
+          npx expo prebuild --platform android
+
+      - name: Setup Gradle wrapper permissions
+        run: chmod +x android/gradlew
+
+      - name: Build Android APK
+        run: |
+          cd android
+          ./gradlew assembleRelease
+        env:
+          ANDROID_HOME: /opt/android
+          ANDROID_SDK_ROOT: /opt/android
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk-${{ github.sha }}
+          path: android/app/build/outputs/apk/release/app-release.apk
+          retention-days: 30
+
+      - name: Comment PR with build info
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const buildStatus = '${{ job.status }}' === 'success' ? '✅ Success' : '❌ Failed';
+            
+            let apkSize = 'Unknown';
+            try {
+              const apkPath = 'android/app/build/outputs/apk/release/app-release.apk';
+              if (fs.existsSync(apkPath)) {
+                const stats = fs.statSync(apkPath);
+                apkSize = `${(stats.size / (1024 * 1024)).toFixed(2)} MB`;
+              }
+            } catch (error) {
+              console.log('Could not get APK size:', error.message);
+            }
+            
+            const workflowUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${{ github.run_id }}`;
+            const artifactUrl = `${workflowUrl}#artifacts`;
+            
+            const comment = `
+            ## 📱 Android Build ${buildStatus}
+            
+            **Build Type:** Container Build (React Native)  
+            **Platform:** Android  
+            **Commit:** ${context.sha.substring(0, 7)}
+            **APK Size:** ${apkSize}
+            **Build Time:** ~45 minutes
+            
+            ${buildStatus === '✅ Success' ? 
+              `🎉 **The Android APK has been built successfully!**
+              
+              ### 📥 Download APK:
+              1. **[Go to Workflow Run](${workflowUrl})**
+              2. **[Direct to Artifacts](${artifactUrl})** 
+              3. Download \`android-apk-${context.sha.substring(0, 7)}\`
+              4. Extract and install the APK
+              
+              ### 📋 Installation:
+              - Enable "Install from Unknown Sources" on your Android device
+              - Transfer the APK to your device and install
+              ` : 
+              `❌ **The Android build failed.**
+              
+              ### 🔍 Debugging:
+              - [Check build logs](${workflowUrl})
+              - Review error messages in the workflow output
+              - Verify all dependencies are compatible`}
+            `;
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            }); 

--- a/local-build.sh
+++ b/local-build.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -e
+
+echo "🚀 Starting local Android build using Podman..."
+
+# Container configuration
+CONTAINER_IMAGE="docker.io/reactnativecommunity/react-native-android:latest"
+CONTAINER_NAME="beegreen-android-build"
+WORKSPACE_DIR="/workspace"
+
+# Clean up any existing container
+echo "🧹 Cleaning up existing containers..."
+podman rm -f $CONTAINER_NAME 2>/dev/null || true
+
+# Pull the latest image
+echo "📦 Pulling React Native Android container..."
+podman pull $CONTAINER_IMAGE
+
+# Run the container with the project mounted
+echo "🐳 Starting build container..."
+podman run -it --rm \
+  --name $CONTAINER_NAME \
+  -v "$(pwd):$WORKSPACE_DIR:Z" \
+  -w $WORKSPACE_DIR \
+  --user root \
+  $CONTAINER_IMAGE \
+  bash -c "
+    set -e
+    echo '📋 Environment setup:'
+    echo 'Node version:' \$(node --version)
+    echo 'NPM version:' \$(npm --version)
+    echo 'Android SDK:' \$ANDROID_HOME
+    echo 'Java version:' \$(java -version 2>&1 | head -1)
+    
+    echo ''
+    echo '📦 Installing dependencies...'
+    npm ci
+    
+    echo ''
+    echo '🔧 Installing Expo CLI...'
+    npm install -g @expo/cli
+    
+    echo ''
+    echo '📱 Setting up Android build environment...'
+    mkdir -p android
+    echo 'sdk.dir=/opt/android' > android/local.properties
+    echo 'ndk.dir=/opt/ndk' >> android/local.properties
+    
+    echo ''
+    echo '🏗️  Running Expo prebuild...'
+    npx expo install --fix
+    
+    # Clean any existing android directory
+    rm -rf android
+    
+    npx expo prebuild --platform android
+    
+    echo ''
+    echo '🔨 Building Android APK...'
+    cd android
+    chmod +x gradlew
+    ./gradlew assembleRelease
+    
+    echo ''
+    echo '✅ Build completed!'
+    echo 'APK location: android/app/build/outputs/apk/release/app-release.apk'
+    
+    # Check if APK was created and show its size
+    if [ -f app/build/outputs/apk/release/app-release.apk ]; then
+      APK_SIZE=\$(du -h app/build/outputs/apk/release/app-release.apk | cut -f1)
+      echo \"📱 APK size: \$APK_SIZE\"
+      ls -la app/build/outputs/apk/release/app-release.apk
+    else
+      echo '❌ APK not found!'
+      exit 1
+    fi
+  "
+
+echo ""
+echo "🎉 Local build completed!"
+echo "The APK should be available at: android/app/build/outputs/apk/release/app-release.apk" 

--- a/local-build.sh
+++ b/local-build.sh
@@ -46,13 +46,13 @@ podman run -it --rm \
     mkdir -p android
     echo 'sdk.dir=/opt/android' > android/local.properties
     echo 'ndk.dir=/opt/ndk' >> android/local.properties
-    
+      
+    # Clean any existing android directory
+    rm -rf android
+
     echo ''
     echo '🏗️  Running Expo prebuild...'
     npx expo install --fix
-    
-    # Clean any existing android directory
-    rm -rf android
     
     npx expo prebuild --platform android
     

--- a/test-container.sh
+++ b/test-container.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -e
+
+echo "🧪 Testing React Native Android container environment..."
+
+# Container configuration
+CONTAINER_IMAGE="docker.io/reactnativecommunity/react-native-android:latest"
+CONTAINER_NAME="beegreen-test"
+WORKSPACE_DIR="/workspace"
+
+# Clean up any existing container
+echo "🧹 Cleaning up existing containers..."
+podman rm -f $CONTAINER_NAME 2>/dev/null || true
+
+# Pull the latest image
+echo "📦 Pulling React Native Android container..."
+podman pull $CONTAINER_IMAGE
+
+# Test the container environment
+echo "🐳 Testing container environment..."
+podman run -it --rm \
+  --name $CONTAINER_NAME \
+  -v "$(pwd):$WORKSPACE_DIR:Z" \
+  -w $WORKSPACE_DIR \
+  --user root \
+  $CONTAINER_IMAGE \
+  bash -c "
+    echo '📋 Container Environment Check:'
+    echo '================================'
+    echo 'Node version:' \$(node --version)
+    echo 'NPM version:' \$(npm --version)
+    echo 'Android SDK location:' \$ANDROID_HOME
+    echo 'Android SDK exists:' \$([ -d \$ANDROID_HOME ] && echo 'YES' || echo 'NO')
+    echo 'Java version:' \$(java -version 2>&1 | head -1)
+    echo 'Gradle available:' \$(which gradle && gradle --version | head -1 || echo 'NOT FOUND')
+    echo ''
+    echo '📱 Android SDK Tools:'
+    echo 'SDK Manager:' \$([ -f \$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager ] && echo 'YES' || echo 'NO')
+    echo 'ADB:' \$(which adb || echo 'NOT FOUND')
+    echo ''
+    echo '📦 Project files:'
+    ls -la | head -10
+    echo ''
+    echo '🔍 Package.json check:'
+    if [ -f package.json ]; then
+      echo 'package.json found ✅'
+      echo 'Project name:' \$(cat package.json | grep '\"name\"' | head -1)
+    else
+      echo 'package.json NOT found ❌'
+    fi
+    echo ''
+    echo '✅ Container test completed!'
+  "
+
+echo ""
+echo "🎉 Container test finished!"
+echo ""
+echo "If everything looks good, run './local-build.sh' to start the full build process." 


### PR DESCRIPTION
added github workflow to build the app from PR
For local testing:
test-container: tests the container environment.
local-build: conatiner way to build full apk locally, takes time to run.

## Summary by Sourcery

Set up a containerized Android build process both in CI and locally, including PR-triggered GitHub Actions, Podman scripts for local builds and environment checks, and accompanying documentation.

New Features:
- Introduce GitHub Actions workflow to build and upload Android APK on pull requests with automated status comments

Enhancements:
- Add Podman-based scripts for local Android build and container environment testing

Documentation:
- Add README to document the GitHub Actions Android build workflow